### PR TITLE
ビューやREADMEの修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,18 +15,18 @@
 ## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|title|string|null: false, unique: true|
+|name|string|null: false, unique: true|
 
 ### Association
 - has_many :messages
 - has_many :groups_users
 - has_many :users, through: :groups_users
 
-## groups_usersテーブル
+## group_usersテーブル
 |Column|Type|Options|
 |------|----|-------|
-|group_id|integer|null: false, foreign_key: true|
-|user_id|integer|null: false, foreign_key: true|
+|group_id|references|null: false, foreign_key: true|
+|user_id|references|null: false, foreign_key: true|
 
 ### Association
 - belongs_to :user
@@ -37,8 +37,8 @@
 |------|----|-------|
 |body|text||
 |image|string||
-|group_id|integer|null: false, foreign_key: true|
-|user_id|integer|null: false, foreign_key: true|
+|group_id|references|null: false, foreign_key: true|
+|user_id|references|null: false, foreign_key: true|
 
 ### Association
 - belongs_to :user

--- a/app/assets/stylesheets/modules/_messages.scss
+++ b/app/assets/stylesheets/modules/_messages.scss
@@ -41,9 +41,11 @@
     height: calc(100vh - 100px);
     background-color: $group-list-background-color;
     overflow: scroll;
+    padding: 0 20px;
 
       .Group{
-        padding: 20px;
+        padding: 20px 0 40px;
+        text-decoration: none;
         
         &__name{
           color: $Side_bar-font-color;
@@ -53,7 +55,6 @@
         &__top-message{
           color: $Side_bar-font-color;
           font-size: 11px;
-          margin-bottom: 20px;
         }
       }
   }

--- a/app/views/messages/_side_bar.html.haml
+++ b/app/views/messages/_side_bar.html.haml
@@ -12,7 +12,7 @@
   .Side_bar__group-list
     - current_user.groups.each do |group|
       .Group
-        = link_to group_messages_path(group) do
+        = link_to group_messages_path(group), class: "Group" do
           .Group__name
             = group.name
           .Group__top-message


### PR DESCRIPTION
# What
グループリストのグループ名とメッセージに下線が現れていたので、見えないようにした。
また、実装時にDBの設計方法を変更したので、情報を反映させた。

# Why
ビューの崩れをなくすことで、快適にアプリケーションを使用することができる。
また、READMEを見るだけで、DBをどのように設計したのかが、第三者が見ても、把握することが出来る。